### PR TITLE
Feat: Add users module

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@hono/node-server": "^1.12.0",
+    "crypto": "^1.0.1",
     "dotenv": "^17.2.2",
     "hono": "^4.7.4",
     "hono-openapi": "^0.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@hono/node-server':
         specifier: ^1.12.0
         version: 1.19.1(hono@4.7.4)
+      crypto:
+        specifier: ^1.0.1
+        version: 1.0.1
       dotenv:
         specifier: ^17.2.2
         version: 17.2.2
@@ -470,6 +473,10 @@ packages:
 
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
+  crypto@1.0.1:
+    resolution: {integrity: sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==}
+    deprecated: This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in.
 
   dateformat@4.6.3:
     resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
@@ -1181,6 +1188,8 @@ snapshots:
   clone@2.1.2: {}
 
   colorette@2.0.20: {}
+
+  crypto@1.0.1: {}
 
   dateformat@4.6.3: {}
 

--- a/src/container.ts
+++ b/src/container.ts
@@ -3,6 +3,7 @@ import { BindingScopeEnum, Container } from 'inversify'
 import { BudgetsRepositoryMongo } from './budgets/infrastructure/repositories/BudgetsRepositoryMongo.ts'
 import { CreateBudget } from './budgets/use-cases/CreateBudget.ts'
 import { CreateBudgetEndpoint } from './budgets/infrastructure/controllers/CreateBudgetEndpoint.ts'
+import { FixedExpensesRepositoryMongo } from './budgets/infrastructure/repositories/FixedExpensesRepositoryMongo.ts'
 import { JwtSignerHono } from './shared/infrastructure/services/jwt/JwtSignerHono.ts'
 import { LoggerPino } from './shared/infrastructure/services/logger/LoggerPino.ts'
 import { RequestContext } from './shared/infrastructure/controllers/middlewares/RequestContext.ts'
@@ -20,6 +21,7 @@ container.bind(Token.ENDPOINT).toConstantValue(CreateBudgetEndpoint)
 
 // Repositories
 container.bind(Token.BUDGETS_REPOSITORY).toDynamicValue(BudgetsRepositoryMongo.create)
+container.bind(Token.FIXED_EXPENSES_REPOSITORY).toDynamicValue(FixedExpensesRepositoryMongo.create)
 
 // Services
 container.bind(Token.LOGGER).toDynamicValue(LoggerPino.create)

--- a/src/container.ts
+++ b/src/container.ts
@@ -3,11 +3,15 @@ import { BindingScopeEnum, Container } from 'inversify'
 import { BudgetsRepositoryMongo } from './budgets/infrastructure/repositories/BudgetsRepositoryMongo.ts'
 import { CreateBudget } from './budgets/use-cases/CreateBudget.ts'
 import { CreateBudgetEndpoint } from './budgets/infrastructure/controllers/CreateBudgetEndpoint.ts'
+import { CryptoNode } from './shared/infrastructure/services/crypto/CryptoNode.ts'
 import { FixedExpensesRepositoryMongo } from './budgets/infrastructure/repositories/FixedExpensesRepositoryMongo.ts'
 import { JwtSignerHono } from './shared/infrastructure/services/jwt/JwtSignerHono.ts'
 import { LoggerPino } from './shared/infrastructure/services/logger/LoggerPino.ts'
+import { RegisterUser } from './users/use-cases/RegisterUser.ts'
+import { RegisterUserEndpoint } from './users/infrastructure/controllers/RegisterUserEndpoint.ts'
 import { RequestContext } from './shared/infrastructure/controllers/middlewares/RequestContext.ts'
 import { Token } from './shared/domain/services/Token.ts'
+import { UsersRepositoryMongo } from './users/infrastructure/repositories/UsersRepositoryMongo.ts'
 import { createHono } from './shared/infrastructure/controllers/CreateHono.ts'
 import { mongoModule } from './shared/infrastructure/repositories/CreateMongoClient.ts'
 
@@ -15,17 +19,21 @@ export const container = new Container({ defaultScope: BindingScopeEnum.Singleto
 
 // Use cases
 container.bind(CreateBudget).toDynamicValue(CreateBudget.create)
+container.bind(RegisterUser).toDynamicValue(RegisterUser.create)
 
 // Controllers
 container.bind(Token.ENDPOINT).toConstantValue(CreateBudgetEndpoint)
+container.bind(Token.ENDPOINT).toConstantValue(RegisterUserEndpoint)
 
 // Repositories
 container.bind(Token.BUDGETS_REPOSITORY).toDynamicValue(BudgetsRepositoryMongo.create)
 container.bind(Token.FIXED_EXPENSES_REPOSITORY).toDynamicValue(FixedExpensesRepositoryMongo.create)
+container.bind(Token.USERS_REPOSITORY).toDynamicValue(UsersRepositoryMongo.create)
 
 // Services
 container.bind(Token.LOGGER).toDynamicValue(LoggerPino.create)
 container.bind(Token.JWT_SIGNER).toConstantValue(new JwtSignerHono())
+container.bind(Token.CRYPTO).toConstantValue(new CryptoNode())
 
 // Libraries
 container.load(mongoModule)

--- a/src/shared/domain/models/EmailAddress.test.ts
+++ b/src/shared/domain/models/EmailAddress.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+import { EmailAddress } from './EmailAddress.ts'
+
+describe('EmailAddress', () => {
+  it('can be converted to string', () => {
+    const emailString = 'someone@example.com'
+    const email = new EmailAddress(emailString)
+
+    const asString = `${email}`
+
+    expect(asString).toEqual(emailString)
+  })
+})

--- a/src/shared/domain/models/EmailAddress.ts
+++ b/src/shared/domain/models/EmailAddress.ts
@@ -1,0 +1,22 @@
+import { ValueObject } from './hex/ValueObject.ts'
+
+export class EmailAddress extends ValueObject {
+  private readonly email: string
+
+  constructor(email: string) {
+    super()
+    this.email = email
+  }
+
+  static fromPrimitives(email: string): EmailAddress {
+    return new EmailAddress(email)
+  }
+
+  toString() {
+    return this.email
+  }
+
+  toPrimitives() {
+    return this.email
+  }
+}

--- a/src/shared/domain/models/HashedPassword.ts
+++ b/src/shared/domain/models/HashedPassword.ts
@@ -1,0 +1,23 @@
+import * as crypto from 'node:crypto'
+import { ValueObject } from './hex/ValueObject.ts'
+
+export class HashedPassword extends ValueObject {
+  private readonly hash: string
+
+  constructor(hash: string) {
+    super()
+    this.hash = hash
+  }
+
+  static fromPrimitives(hash: string): HashedPassword {
+    return new HashedPassword(hash)
+  }
+
+  toPrimitives() {
+    return this.hash
+  }
+
+  equalsTo(password: HashedPassword) {
+    return crypto.timingSafeEqual(Buffer.from(this.hash), Buffer.from(password.hash))
+  }
+}

--- a/src/shared/domain/models/PlainPassword.test.ts
+++ b/src/shared/domain/models/PlainPassword.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { HashedPassword } from './HashedPassword.ts'
+import { PlainPassword } from './PlainPassword.ts'
+
+describe('PlainPassword', () => {
+  const hashOfPasswordAndSalt = HashedPassword.fromPrimitives(
+    'afe6c5530785b6cc6b1c6453384731bd5ee432ee549fd42fb6695779ad8a1c5bf59de69c48f774efc4007d5298f9033c0241d5ab69305e7b64eceeb8d834cfec',
+  )
+
+  it('converts to a hashed password', () => {
+    const plainPassword = new PlainPassword('password')
+    const salt = 'salt'
+    const hashedPassword = plainPassword.toHashed(salt)
+
+    expect(hashedPassword.equalsTo(hashOfPasswordAndSalt)).toBe(true)
+  })
+
+  it('comparison fails if password is wrong', () => {
+    const plainPassword = new PlainPassword('wrong password')
+    const salt = 'salt'
+    const hashedPassword = plainPassword.toHashed(salt)
+
+    expect(hashedPassword.equalsTo(hashOfPasswordAndSalt)).toBe(false)
+  })
+
+  it('comparison fails if salt is wrong', () => {
+    const plainPassword = new PlainPassword('password')
+    const salt = 'wrong salt'
+    const hashedPassword = plainPassword.toHashed(salt)
+
+    expect(hashedPassword.equalsTo(hashOfPasswordAndSalt)).toBe(false)
+  })
+})

--- a/src/shared/domain/models/PlainPassword.ts
+++ b/src/shared/domain/models/PlainPassword.ts
@@ -1,0 +1,22 @@
+import * as crypto from 'node:crypto'
+
+import { HashedPassword } from './HashedPassword.ts'
+import { ValueObject } from './hex/ValueObject.ts'
+
+export class PlainPassword extends ValueObject {
+  private readonly password: string
+
+  constructor(password: string) {
+    super()
+    this.password = password
+  }
+
+  static fromPrimitives(password: string): PlainPassword {
+    return new PlainPassword(password)
+  }
+
+  toHashed(salt: string) {
+    const hash = crypto.pbkdf2Sync(this.password, salt, 1000, 64, 'sha512').toString('hex')
+    return new HashedPassword(hash)
+  }
+}

--- a/src/shared/domain/services/Crypto.ts
+++ b/src/shared/domain/services/Crypto.ts
@@ -1,0 +1,3 @@
+export interface Crypto {
+  generateSalt(): Promise<string>
+}

--- a/src/shared/domain/services/Token.ts
+++ b/src/shared/domain/services/Token.ts
@@ -6,6 +6,8 @@ export const Token = {
   DB_CONFIG: 'DB_CONFIG',
   BUDGETS_REPOSITORY: 'BUDGETS_REPOSITORY',
   FIXED_EXPENSES_REPOSITORY: 'FIXED_EXPENSES_REPOSITORY',
+  USERS_REPOSITORY: 'USERS_REPOSITORY',
+  CRYPTO: 'CRYPTO',
 } as const
 
 export type Token = (typeof Token)[keyof typeof Token]

--- a/src/shared/infrastructure/controllers/schemas/ApiTag.ts
+++ b/src/shared/infrastructure/controllers/schemas/ApiTag.ts
@@ -1,5 +1,6 @@
 export const ApiTag = {
   BUDGETS: 'Budgets',
+  USERS: 'Users',
 }
 
 export type ApiTag = (typeof ApiTag)[keyof typeof ApiTag]

--- a/src/shared/infrastructure/services/crypto/CryptoFixed.ts
+++ b/src/shared/infrastructure/services/crypto/CryptoFixed.ts
@@ -1,0 +1,7 @@
+import type { Crypto } from '../../../domain/services/Crypto.ts'
+
+export class CryptoFixed implements Crypto {
+  async generateSalt(): Promise<string> {
+    return 'salt'
+  }
+}

--- a/src/shared/infrastructure/services/crypto/CryptoNode.test.ts
+++ b/src/shared/infrastructure/services/crypto/CryptoNode.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+import { CryptoNode } from './CryptoNode.ts'
+
+describe('CryptoNode', () => {
+  it('generate a random salt', async () => {
+    const cryptoNode = new CryptoNode()
+
+    const salt1 = await cryptoNode.generateSalt()
+    const salt2 = await cryptoNode.generateSalt()
+
+    expect(salt1).not.toBe(salt2)
+  })
+})

--- a/src/shared/infrastructure/services/crypto/CryptoNode.ts
+++ b/src/shared/infrastructure/services/crypto/CryptoNode.ts
@@ -1,0 +1,8 @@
+import * as crypto from 'node:crypto'
+import type { Crypto } from '../../../domain/services/Crypto.ts'
+
+export class CryptoNode implements Crypto {
+  async generateSalt(): Promise<string> {
+    return crypto.randomBytes(16).toString('hex')
+  }
+}

--- a/src/users/domain/models/User.ts
+++ b/src/users/domain/models/User.ts
@@ -1,0 +1,93 @@
+import { EmailAddress } from '../../../shared/domain/models/EmailAddress.ts'
+import { HashedPassword } from '../../../shared/domain/models/HashedPassword.ts'
+import type { PlainPassword } from '../../../shared/domain/models/PlainPassword.ts'
+import type { Primitives } from '../../../shared/domain/models/hex/Primitives.ts'
+import { UserId } from '../../../shared/domain/models/ids/UserId.ts'
+import { UuidGeneratorRandom } from '../../../shared/infrastructure/services/uuid-generator/UuidGeneratorRandom.ts'
+
+export type UserPrimitives = Primitives<User>
+
+export class User {
+  private id: UserId
+
+  private name: string
+
+  private lastName: string
+
+  private email: EmailAddress
+
+  private password: HashedPassword
+
+  private salt: string
+
+  private createdAt: Date
+
+  private updatedAt?: Date
+
+  constructor(
+    id: UserId,
+    name: string,
+    lastName: string,
+    email: EmailAddress,
+    password: HashedPassword,
+    salt: string,
+    createdAt: Date,
+    updatedAt?: Date
+  ) {
+    this.id = id
+    this.name = name
+    this.lastName = lastName
+    this.email = email
+    this.password = password
+    this.salt = salt
+    this.createdAt = createdAt
+    this.updatedAt = updatedAt
+  }
+
+  static register(
+    name: string,
+    lastName: string,
+    email: EmailAddress,
+    password: PlainPassword,
+    salt: string
+  ): User {
+    const hash = password.toHashed(salt)
+    const id = new UserId(UuidGeneratorRandom.generate())
+    return new User(id, name, lastName, email, hash, salt, new Date())
+  }
+
+  static fromPrimitives({
+    id,
+    name,
+    lastName,
+    email,
+    password,
+    salt,
+    createdAt,
+    updatedAt,
+  }: UserPrimitives): User {
+    return new User(
+      UserId.fromPrimitives(id),
+      name,
+      lastName,
+      EmailAddress.fromPrimitives(email),
+      HashedPassword.fromPrimitives(password),
+      salt,
+      createdAt,
+      updatedAt ? new Date(updatedAt) : undefined
+    )
+  }
+
+  toPrimitives() {
+    return {
+      id: this.id.toPrimitives(),
+      name: this.name,
+      lastName: this.lastName,
+      email: this.email.toPrimitives(),
+      password: this.password.toPrimitives(),
+      salt: this.salt,
+      createdAt: this.createdAt,
+      updatedAt: this.updatedAt,
+    }
+  }
+}

--- a/src/users/domain/repositories/UsersRepository.ts
+++ b/src/users/domain/repositories/UsersRepository.ts
@@ -1,0 +1,9 @@
+import type { EmailAddress } from '../../../shared/domain/models/EmailAddress.ts'
+import type { User } from '../models/User.ts'
+import type { UserId } from '../../../shared/domain/models/ids/UserId.ts'
+
+export interface UsersRepository {
+  save(user: User): Promise<void>
+  findOneById(id: UserId): Promise<User | undefined>
+  existsWith(email: EmailAddress): Promise<boolean>
+}

--- a/src/users/infrastructure/controllers/RegisterUserEndpoint.ts
+++ b/src/users/infrastructure/controllers/RegisterUserEndpoint.ts
@@ -1,0 +1,41 @@
+import { validator } from 'hono-openapi/zod'
+import { factory, type Endpoint } from '../../../shared/infrastructure/controllers/factory.ts'
+
+import { describeRoute } from 'hono-openapi'
+import { EmailAddress } from '../../../shared/domain/models/EmailAddress.ts'
+import { PlainPassword } from '../../../shared/domain/models/PlainPassword.ts'
+import { ApiTag } from '../../../shared/infrastructure/controllers/schemas/ApiTag.ts'
+import { RegisterUser } from '../../use-cases/RegisterUser.ts'
+import { RegisterUserRequestDTO } from './dtos/RegisterUserRequestDTO.ts'
+
+export const RegisterUserEndpoint = {
+  method: 'post',
+  path: '/api/v1/users/registration',
+  secured: false,
+  handlers: factory.createHandlers(
+    describeRoute({
+      summary: 'Register a new user',
+      description: 'Registers a new user',
+      tags: [ApiTag.USERS],
+      security: [{ bearerAuth: [] }],
+      responses: {
+        201: {
+          description: 'User registered',
+        },
+      },
+    }),
+    validator('json', RegisterUserRequestDTO),
+    async (c) => {
+      const registerUser = await c.var.container.getAsync(RegisterUser)
+
+      const body = c.req.valid('json')
+      await registerUser.execute({
+        name: body.name,
+        lastName: body.lastName,
+        email: EmailAddress.fromPrimitives(body.email),
+        password: PlainPassword.fromPrimitives(body.password),
+      })
+      return c.body(null, 201)
+    }
+  ),
+} satisfies Endpoint

--- a/src/users/infrastructure/controllers/dtos/RegisterUserRequestDTO.ts
+++ b/src/users/infrastructure/controllers/dtos/RegisterUserRequestDTO.ts
@@ -1,0 +1,8 @@
+import { z } from '../../../../shared/infrastructure/controllers/zod.ts'
+
+export const RegisterUserRequestDTO = z.object({
+  name: z.string(),
+  lastName: z.string(),
+  email: z.string().email(),
+  password: z.string(),
+})

--- a/src/users/infrastructure/repositories/UsersRepositoryMemory.ts
+++ b/src/users/infrastructure/repositories/UsersRepositoryMemory.ts
@@ -1,0 +1,40 @@
+import type { EmailAddress } from '../../../shared/domain/models/EmailAddress.ts'
+import type { UserId } from '../../../shared/domain/models/ids/UserId.ts'
+import type { Closable } from '../../../shared/infrastructure/repositories/Closable.ts'
+import type { Reseteable } from '../../../shared/infrastructure/repositories/Reseteable.ts'
+import { User, type UserPrimitives } from '../../domain/models/User.ts'
+import type { UsersRepository } from '../../domain/repositories/UsersRepository.ts'
+
+export class UsersRepositoryMemory implements UsersRepository, Reseteable, Closable {
+  public static create() {
+    return new UsersRepositoryMemory()
+  }
+
+  protected users: Map<string, UserPrimitives> = new Map()
+
+  async save(user: User): Promise<void> {
+    this.saveSync(user)
+  }
+
+  protected saveSync(user: User) {
+    const userPrimitives = user.toPrimitives()
+    this.users.set(userPrimitives.id, userPrimitives)
+  }
+
+  async findOneById(id: UserId): Promise<User | undefined> {
+    const userPrimitives = this.users.get(id.toPrimitives())
+    if (!userPrimitives) return undefined
+
+    return User.fromPrimitives(userPrimitives)
+  }
+
+  async existsWith(email: EmailAddress): Promise<boolean> {
+    return this.users.values().some((user) => user.email === email.toPrimitives())
+  }
+
+  async reset() {
+    this.users.clear()
+  }
+
+  async close(): Promise<void> {}
+}

--- a/src/users/infrastructure/repositories/UsersRepositoryMongo.integration-test.ts
+++ b/src/users/infrastructure/repositories/UsersRepositoryMongo.integration-test.ts
@@ -1,0 +1,102 @@
+import { BindingScopeEnum, Container } from 'inversify'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+
+import type { Closable } from '../../../shared/infrastructure/repositories/Closable.ts'
+import { EmailAddress } from '../../../shared/domain/models/EmailAddress.ts'
+import { HashedPassword } from '../../../shared/domain/models/HashedPassword.ts'
+import { PlainPassword } from '../../../shared/domain/models/PlainPassword.ts'
+import type { Reseteable } from '../../../shared/infrastructure/repositories/Reseteable.ts'
+import { Token } from '../../../shared/domain/services/Token.ts'
+import { User } from '../../domain/models/User.ts'
+import { UserId } from '../../../shared/domain/models/ids/UserId.ts'
+import type { UsersRepository } from '../../domain/repositories/UsersRepository.ts'
+import { UsersRepositoryMongo } from './UsersRepositoryMongo.ts'
+import { UuidGeneratorRandom } from '../../../shared/infrastructure/services/uuid-generator/UuidGeneratorRandom.ts'
+import { mongoModule } from '../../../shared/infrastructure/repositories/CreateMongoClient.ts'
+import { testMongoOptions } from '../../../../test/config/testMongoOptions.ts'
+
+describe('UsersRepositoryMongo', () => {
+  const container = new Container({ defaultScope: BindingScopeEnum.Singleton })
+  container.bind(UsersRepositoryMongo).toDynamicValue(UsersRepositoryMongo.create)
+  container.load(mongoModule)
+  container.rebind(Token.DB_CONFIG).toConstantValue(testMongoOptions)
+
+  describe.each([{ repositoryClass: UsersRepositoryMongo }])(
+    '$repositoryClass.name',
+    ({ repositoryClass }) => {
+      let usersRepository: UsersRepository & Reseteable & Closable
+
+      beforeAll(async () => {
+        usersRepository = await container.getAsync(repositoryClass)
+      })
+
+      beforeEach(async () => {
+        await usersRepository.reset()
+      })
+
+      afterAll(async () => {
+        await usersRepository.close()
+      })
+
+      it('should save a user', async () => {
+        const email = EmailAddress.fromPrimitives('test@example.com')
+        const password = PlainPassword.fromPrimitives('testPassword123')
+        const user = User.register('Juan', 'Pérez', email, password, 'test-salt-123')
+
+        await usersRepository.save(user)
+
+        const userPrimitives = user.toPrimitives()
+        const savedUser = await usersRepository.findOneById(
+          UserId.fromPrimitives(userPrimitives.id)
+        )
+
+        expect(savedUser).toEqual(user)
+      })
+
+      it('should find a user by id', async () => {
+        const userId = new UserId(UuidGeneratorRandom.generate())
+        const email = EmailAddress.fromPrimitives('find@example.com')
+        const hashedPassword = HashedPassword.fromPrimitives('hashed-password-123')
+        const user = new User(
+          userId,
+          'Ana',
+          'García',
+          email,
+          hashedPassword,
+          'salt-123',
+          new Date()
+        )
+
+        await usersRepository.save(user)
+
+        const foundUser = await usersRepository.findOneById(userId)
+
+        expect(foundUser).toEqual(user)
+      })
+
+      it('should return undefined when user not found by id', async () => {
+        const nonExistentUserId = new UserId(UuidGeneratorRandom.generate())
+
+        const foundUser = await usersRepository.findOneById(nonExistentUserId)
+
+        expect(foundUser).toBeUndefined()
+      })
+
+      it('should check if user exists with email', async () => {
+        const email = EmailAddress.fromPrimitives('exists@example.com')
+        const password = PlainPassword.fromPrimitives('password123')
+        const user = User.register('Carlos', 'López', email, password, 'salt-456')
+
+        await usersRepository.save(user)
+
+        const exists = await usersRepository.existsWith(email)
+        const notExists = await usersRepository.existsWith(
+          EmailAddress.fromPrimitives('nonexistent@example.com')
+        )
+
+        expect(exists).toBe(true)
+        expect(notExists).toBe(false)
+      })
+    }
+  )
+})

--- a/src/users/infrastructure/repositories/UsersRepositoryMongo.ts
+++ b/src/users/infrastructure/repositories/UsersRepositoryMongo.ts
@@ -1,0 +1,42 @@
+import type { interfaces } from 'inversify'
+import { Collection, Db } from 'mongodb'
+import type { EmailAddress } from '../../../shared/domain/models/EmailAddress.ts'
+import { UserId } from '../../../shared/domain/models/ids/UserId.ts'
+import { User, type UserPrimitives } from '../../domain/models/User.ts'
+import type { UsersRepository } from '../../domain/repositories/UsersRepository.ts'
+import type { Closable } from '../../../shared/infrastructure/repositories/Closable.ts'
+import type { Reseteable } from '../../../shared/infrastructure/repositories/Reseteable.ts'
+
+export class UsersRepositoryMongo implements UsersRepository, Reseteable, Closable {
+  public static async create({ container }: interfaces.Context) {
+    const db = await container.getAsync(Db)
+    return new UsersRepositoryMongo(db)
+  }
+
+  private readonly users: Collection<UserPrimitives>
+
+  constructor(db: Db) {
+    this.users = db.collection('users')
+  }
+
+  async save(user: User): Promise<void> {
+    const primitives = user.toPrimitives()
+    await this.users.updateOne({ id: primitives.id }, { $set: primitives }, { upsert: true })
+  }
+
+  async findOneById(id: UserId): Promise<User | undefined> {
+    const primitives = await this.users.findOne({ id: id.toPrimitives() })
+    return primitives ? User.fromPrimitives(primitives) : undefined
+  }
+
+  async existsWith(email: EmailAddress): Promise<boolean> {
+    const count = await this.users.countDocuments({ email: email.toPrimitives() })
+    return count > 0
+  }
+
+  async reset() {
+    await this.users.deleteMany()
+  }
+
+  async close(): Promise<void> {}
+}

--- a/src/users/use-cases/RegisterUser.test.ts
+++ b/src/users/use-cases/RegisterUser.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { CryptoNode } from '../../shared/infrastructure/services/crypto/CryptoNode.ts'
+import { EmailAddress } from '../../shared/domain/models/EmailAddress.ts'
+import { PlainPassword } from '../../shared/domain/models/PlainPassword.ts'
+import { RegisterUser } from './RegisterUser.ts'
+import type { UsersRepository } from '../domain/repositories/UsersRepository.ts'
+import { UsersRepositoryMemory } from '../infrastructure/repositories/UsersRepositoryMemory.ts'
+
+describe('RegisterUser', () => {
+  let registerUser: RegisterUser
+  let usersRepository: UsersRepository
+
+  beforeEach(() => {
+    usersRepository = UsersRepositoryMemory.create()
+
+    registerUser = new RegisterUser(usersRepository, new CryptoNode())
+  })
+
+  it('should register a new user with hashed password', async () => {
+    const name = 'Juan'
+    const lastName = 'Pérez'
+    const email = EmailAddress.fromPrimitives('juan.perez@example.com')
+    const password = PlainPassword.fromPrimitives('miPasswordSegura123')
+
+    await registerUser.execute({
+      name,
+      lastName,
+      email,
+      password,
+    })
+
+    const isUserExists = await usersRepository.existsWith(email)
+
+    expect(isUserExists).toBeTruthy()
+  })
+})

--- a/src/users/use-cases/RegisterUser.ts
+++ b/src/users/use-cases/RegisterUser.ts
@@ -1,0 +1,46 @@
+import type { Crypto } from '../../shared/domain/services/Crypto.ts'
+import type { EmailAddress } from '../../shared/domain/models/EmailAddress.ts'
+import type { PlainPassword } from '../../shared/domain/models/PlainPassword.ts'
+import { Token } from '../../shared/domain/services/Token.ts'
+import { UseCase } from '../../shared/domain/models/hex/UseCase.ts'
+import { User } from '../domain/models/User.ts'
+import type { UserId } from '../../shared/domain/models/ids/UserId.ts'
+import type { UsersRepository } from '../domain/repositories/UsersRepository.ts'
+import type { interfaces } from 'inversify'
+
+export type RegisterUserParams = {
+  name: string
+  lastName: string
+  email: EmailAddress
+  password: PlainPassword
+}
+
+export class RegisterUser extends UseCase {
+  public static async create({ container }: interfaces.Context) {
+    return new RegisterUser(
+      ...(await Promise.all([
+        container.getAsync<UsersRepository>(Token.USERS_REPOSITORY),
+        container.getAsync<Crypto>(Token.CRYPTO),
+      ]))
+    )
+  }
+
+  private readonly usersRepository: UsersRepository
+
+  private readonly crypto: Crypto
+
+  constructor(usersRepository: UsersRepository, crypto: Crypto) {
+    super()
+    this.usersRepository = usersRepository
+    this.crypto = crypto
+  }
+
+  async execute({ name, lastName, email, password }: RegisterUserParams) {
+    const emailAlreadyExists = await this.usersRepository.existsWith(email)
+    if (emailAlreadyExists) {
+      throw new Error(`User with email ${email} already exists`) // TODO: Create a custom error
+    }
+    const user = User.register(name, lastName, email, password, await this.crypto.generateSalt())
+    await this.usersRepository.save(user)
+  }
+}

--- a/test/setups/container.ts
+++ b/test/setups/container.ts
@@ -1,6 +1,8 @@
 import { BudgetsRepositoryMemory } from '../../src/budgets/infrastructure/repositories/BudgetsRepositoryMemory.ts'
+import { FixedExpensesRepositoryMemory } from '../../src/budgets/infrastructure/repositories/FixedExpensesRepositoryMemory.ts'
 import { LoggerDummy } from '../../src/shared/infrastructure/services/logger/LoggerDummy.ts'
 import { Token } from '../../src/shared/domain/services/Token.ts'
+import { UsersRepositoryMemory } from '../../src/users/infrastructure/repositories/UsersRepositoryMemory.ts'
 import { config } from '../../src/shared/infrastructure/config.ts'
 import { container as prodContainer } from '../../src/container.ts'
 import { testMongoOptions } from '../config/testMongoOptions.ts'
@@ -10,6 +12,10 @@ prodContainer.rebind(Token.LOGGER).toConstantValue(new LoggerDummy())
 
 if (!config.forceEnableORMRepositories) {
   prodContainer.rebind(Token.BUDGETS_REPOSITORY).toDynamicValue(BudgetsRepositoryMemory.create)
+  prodContainer.rebind(Token.USERS_REPOSITORY).toDynamicValue(UsersRepositoryMemory.create)
+  prodContainer
+    .rebind(Token.FIXED_EXPENSES_REPOSITORY)
+    .toDynamicValue(FixedExpensesRepositoryMemory.create)
 }
 
 export const container = prodContainer

--- a/test/setups/globalSetup.ts
+++ b/test/setups/globalSetup.ts
@@ -17,7 +17,11 @@ beforeAll(async (context) => {
   }
   const { container } = await import('./container.ts')
 
-  repos = await Promise.all([container.getAsync<Closable & Reseteable>(Token.BUDGETS_REPOSITORY)])
+  repos = await Promise.all([
+    container.getAsync<Closable & Reseteable>(Token.BUDGETS_REPOSITORY),
+    container.getAsync<Closable & Reseteable>(Token.FIXED_EXPENSES_REPOSITORY),
+    container.getAsync<Closable & Reseteable>(Token.USERS_REPOSITORY),
+  ])
 })
 
 beforeEach(async (context) => {


### PR DESCRIPTION
### Changelog

This pull request introduces user registration functionality and the supporting infrastructure for secure password handling. It adds new domain models for users and passwords, implements repositories for user persistence, and provides cryptographic services for password salting and hashing. The changes also include new endpoints and validation schemas for user registration, along with tests to ensure correctness.

**User Registration and Domain Models**
* Added the `User` domain model with registration logic, supporting name, last name, email, hashed password, salt, and timestamps (`src/users/domain/models/User.ts`).
* Introduced value objects for `EmailAddress`, `PlainPassword`, and `HashedPassword`, including conversion, hashing, and secure comparison methods (`src/shared/domain/models/EmailAddress.ts`, `src/shared/domain/models/PlainPassword.ts`, `src/shared/domain/models/HashedPassword.ts`). [[1]](diffhunk://#diff-20eb189c3c6ed21a02cb1314a3022007f7975239232c6154c211d5e0916ed41aR1-R22) [[2]](diffhunk://#diff-73d9c4445695581109b828cc3e91be1e30bb067c7a83a6cbb91fe5438482d510R1-R22) [[3]](diffhunk://#diff-7f293bda2d3b49f21d2872ba5960f81290356161edaad094c7910628d949a3efR1-R23)

**Repositories and Persistence**
* Implemented `UsersRepository` interface and concrete in-memory and MongoDB-backed repositories for user storage, with methods for saving, retrieving, and checking existence by email (`src/users/domain/repositories/UsersRepository.ts`, `src/users/infrastructure/repositories/UsersRepositoryMemory.ts`, `src/users/infrastructure/repositories/UsersRepositoryMongo.integration-test.ts`). [[1]](diffhunk://#diff-3dec6b2541bd601a706d2effa5cf9f5b373a1be2e39ae0e9b020ee7d07989b1dR1-R9) [[2]](diffhunk://#diff-1a39b005a8d4c314ff3ec291c727cdb7b33bdcc526f3e856f3efd3c8bf2749baR1-R40) [[3]](diffhunk://#diff-e634effecfdbc727f4227c2dfd201a3f3e5fae3de4ecfc37cef30818450b5837R1-R102)

**Cryptographic Services**
* Added the `Crypto` service interface and two implementations: `CryptoNode` for generating random salts using Node.js crypto, and `CryptoFixed` for deterministic salt generation in tests (`src/shared/domain/services/Crypto.ts`, `src/shared/infrastructure/services/crypto/CryptoNode.ts`, `src/shared/infrastructure/services/crypto/CryptoFixed.ts`). [[1]](diffhunk://#diff-1ca2ecb771a59f7322545453cf3e95d39cd400a1d917e4d55ed468ad22cdd68bR1-R3) [[2]](diffhunk://#diff-bcb4e33a9524446ad050f514529852a0e8d643c6e4678f5be2ec78c42d802dddR1-R8) [[3]](diffhunk://#diff-e1e027f3a18724912155a0e2d74bb9700e3588a40cf3aee027d608af80448674R1-R7)
* Registered cryptographic services in the IoC container for dependency injection (`src/container.ts`).

**API Endpoint and Validation**
* Added the user registration endpoint (`/api/v1/users/registration`) with request validation and handler logic, including DTO schema for incoming user data (`src/users/infrastructure/controllers/RegisterUserEndpoint.ts`, `src/users/infrastructure/controllers/dtos/RegisterUserRequestDTO.ts`). [[1]](diffhunk://#diff-acbc8213fd61320226b8015cfb16889a2a8c4d4cd477a2de29ff3da18b27cdf7R1-R41) [[2]](diffhunk://#diff-7fff04400a7916296973f5cfe81ee299005297dc2e2b53f2abd547b3839e89ffR1-R8)
* Updated API tags to include `USERS` for documentation purposes (`src/shared/infrastructure/controllers/schemas/ApiTag.ts`).

**Dependency and Test Updates**
* Added the `crypto` package to dependencies and lockfiles, though noted as deprecated in favor of Node’s built-in module (`package.json`, `pnpm-lock.yaml`). [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R13) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR14-R16) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR477-R480) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1192-R1193)
* Added comprehensive unit and integration tests for email, password, cryptographic services, and user repository behavior (`src/shared/domain/models/EmailAddress.test.ts`, `src/shared/domain/models/PlainPassword.test.ts`, `src/shared/infrastructure/services/crypto/CryptoNode.test.ts`, `src/users/infrastructure/repositories/UsersRepositoryMongo.integration-test.ts`). [[1]](diffhunk://#diff-3a5df5e067936dfae5fb3a5a242e7a2452f71a1dbfd31fa15d91c745c02db048R1-R13) [[2]](diffhunk://#diff-ce03d9970b8fbcc9cffa98ed12ae649643635092334bb41836277e326667f333R1-R33) [[3]](diffhunk://#diff-d369b16f4fc84e43afe87d6393bac35ad55093eaf64ee3848a84e0cf419d8220R1-R13) [[4]](diffhunk://#diff-e634effecfdbc727f4227c2dfd201a3f3e5fae3de4ecfc37cef30818450b5837R1-R102)